### PR TITLE
Added command line options

### DIFF
--- a/compression_tool/Argument.cs
+++ b/compression_tool/Argument.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace BigFileTools
+{
+    class Argument
+    {
+        static public Argument Null = new Argument(false); 
+
+        public bool Exist { get; }
+        public List<string> Parameters { get; } = new List<string>();
+          
+        public Argument(bool exist)
+        {
+            Exist = exist;
+        }
+        public Argument(List<string> parameters) : this(parameters.Count > 0)
+        {
+            Parameters = parameters;
+        }
+    }
+}

--- a/compression_tool/ArgumentListParser.cs
+++ b/compression_tool/ArgumentListParser.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace BigFileTools
+{
+    class ArgumentListParser
+    {
+        public Argument Help { get; } = Argument.Null;
+        public Argument Task { get; } = Argument.Null;
+        public Argument Input { get; } = Argument.Null;
+        public Argument Output { get; } = Argument.Null;
+        public Argument ForceReplace { get; } = Argument.Null;
+        public bool IsValid => Task.Exist && Input.Exist && Output.Exist;
+
+        public ArgumentListParser(string[] arglist)
+        {
+            for (var i = 0; i < arglist.Length; ++i)
+            {
+                var arg = arglist[i];
+                if (!IsOption(arg))
+                {
+                    throw new ArgumentException($"{arg} is not an option. Type -h or --help to see what options are available.");
+                }
+
+                var parameters = FetchParameterList(arglist, i + 1);
+                i += parameters.Count;
+
+                switch (arg)
+                {
+                    case "-h":
+                    case "--help":
+                        Help = new Argument(true);
+                        break;
+
+                    case "-t":
+                    case "--task":
+                        Task = new Argument(parameters);
+                        break;
+
+                    case "-i":
+                    case "--input":
+                        Input = new Argument(parameters);
+                        break;
+
+                    case "-o":
+                    case "--output":
+                        Output = new Argument(parameters);
+                        break;
+
+                    case "-f":
+                    case "--force-replace":
+                        ForceReplace = new Argument(true);
+                        break;
+                }
+            }
+        }
+
+        private static bool IsOption(string arg)
+        {
+            return arg.StartsWith("--") ||arg.StartsWith("-");
+        }
+
+        private static List<string> FetchParameterList(string[] arglist, int start)
+        {
+            var parameter_list = new List<string>();
+
+            for (var i = start; i < arglist.Length; ++i)
+            {
+                var arg = arglist[i];
+
+                if (IsOption(arg))
+                {
+                    break;
+                }
+
+                parameter_list.Add(arg);
+            }
+
+            return parameter_list;
+        }
+    }
+}

--- a/compression_tool/Program.cs
+++ b/compression_tool/Program.cs
@@ -1,39 +1,98 @@
-﻿using System;
+﻿using BigFileTools;
+using System;
 using System.IO;
 using System.IO.Compression;
+using System.Reflection;
 
+namespace BigFileTools
+{
 public static class BigFileCompression
 {
-    private const string CompressedFileName = "bigfile";
-    private const string ReCompressedFileName = "bigfile.recomp";
-    private const string ModFileName = "bigfile.mod";
-    private const string DecompressedFileName = "bigfile.decomp";
-
-    public static void Main()
+    public static void Main(string[] arglist)
     {
-        if (File.Exists(ModFileName)) {
-            CompressFile();
-            Console.WriteLine($"Created compressed file '{ReCompressedFileName}'.");
+        var arguments = new ArgumentListParser(arglist);
+        if (arguments.Help.Exist || !arguments.IsValid)
+        {
+            if (!arguments.IsValid)
+            {
+                Console.WriteLine("Invalid arguments.");
+            }
+            PrintHelp();
+            return;
         }
-        if (!File.Exists(DecompressedFileName)) {
-            DecompressFile();
-            Console.WriteLine($"Decompressed file '{DecompressedFileName}'.");
+
+        var input_path = arguments.Input.Parameters.First();
+        if (!File.Exists(input_path))
+        {
+            Console.WriteLine($"{input_path} does not exist; please provide a valid target.");
+            return;
+        }
+
+        var output_path = arguments.Output.Parameters.First();
+        if (File.Exists(output_path) && !arguments.ForceReplace.Exist)
+        {
+            Console.WriteLine($"{output_path} already exist; confirm overwrite? (y/n)");
+            var decision = Console.ReadLine();
+            switch (decision)
+            {
+                default:
+                    Console.WriteLine($"Task aborted; {output_path} already exist.");
+                    return;
+
+                case "y":
+                    break;
+            }
+        }
+
+        var task = arguments.Task.Parameters.First();
+        switch (task)
+        {
+            default:
+                Console.WriteLine("Invalid task was provided.");
+                Console.WriteLine("  Valid tasks are: c for compression, d for decompression");
+                return;
+
+            case "c":
+                CompressFile(input_path, output_path);
+                Console.WriteLine($"Created compressed file '{output_path}'.");
+                break;
+
+            case "d":
+                DecompressFile(input_path, output_path);
+                Console.WriteLine($"Decompressed file '{output_path}'.");
+                break;
         }
     }
 
-    private static void CompressFile()
+    private static void CompressFile(string inputPath, string outputPath)
     {
-        using FileStream modFileStream = File.Open(ModFileName, FileMode.Open);
-        using FileStream compressedFileStream = File.Create(ReCompressedFileName);
+        using FileStream modFileStream = File.Open(inputPath, FileMode.Open);
+        using FileStream compressedFileStream = File.Create(outputPath);
         using var compressor = new DeflateStream(compressedFileStream, CompressionMode.Compress);
         modFileStream.CopyTo(compressor);
     }
 
-    private static void DecompressFile()
+    private static void DecompressFile(string inputPath, string outputPath)
     {
-        using FileStream compressedFileStream = File.Open(CompressedFileName, FileMode.Open);
-        using FileStream outputFileStream = File.Create(DecompressedFileName);
+        using FileStream compressedFileStream = File.Open(inputPath, FileMode.Open);
+        using FileStream outputFileStream = File.Create(outputPath);
         using var decompressor = new DeflateStream(compressedFileStream, CompressionMode.Decompress);
         decompressor.CopyTo(outputFileStream);
     }
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine("The following commands exist:");
+        Console.WriteLine("  -h, --help\t\tShows this help message.");
+        Console.WriteLine("  -t, --task\t\tThe task to execute on the input file.");
+        Console.WriteLine("    Valid tasks are: c for compression, d for decompression");
+        Console.WriteLine("  -i, --input\t\tThe path to the input file.");
+        Console.WriteLine("  -o, --output\t\tThe path to the output file.");
+        Console.WriteLine("  -f, --force-replace\tForce the output file to be replaced even if it already exist.");
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine($"Decompress a bigfile: -t d -i \"bigfile\" -o \"bigfile.decomp\"");
+        Console.WriteLine($"Compress a bigfile: -t c -i \"bigfile.decomp\" -o \"bigfile.recomp\"");
+    }
+}
 }


### PR DESCRIPTION
Changed the way the compresssion_tools works by adding command lines.
```
The following commands exist:
  -h, --help		Shows this help message.
  -t, --task		The task to execute on the input file.
    Valid tasks are: c for compression, d for decompression
  -i, --input		The path to the input file.
  -o, --output		The path to the output file.
  -f, --force-replace	Force the output file to be replaced even if it already exist.
  
Examples:
Decompress a bigfile: -t d -i "bigfile" -o "bigfile.decomp"
Compress a bigfile: -t c -i "bigfile.decomp" -o "bigfile.recomp"
```